### PR TITLE
Improve notification performance

### DIFF
--- a/Sources/bebop-vapor/Controllers/NotificationController.swift
+++ b/Sources/bebop-vapor/Controllers/NotificationController.swift
@@ -56,6 +56,10 @@ struct NotificationController: RouteCollection {
                 )
                 try await registration.save(on: req.db)
             }
+
+            // Update in-memory cache for faster lookups
+            await StellarNotificationService.shared(app: req.application)
+                .cacheDeviceToken(request.deviceToken, for: request.stellarAccount)
             
             // Start monitoring the Stellar account
             do {


### PR DESCRIPTION
## Summary
- cache device tokens in `StellarNotificationService`
- update cache whenever a device registers
- handle invalid tokens by removing them from cache and DB

## Testing
- `swift test` *(fails: Failed to clone repository)*